### PR TITLE
Update supported-value.js

### DIFF
--- a/lib/supported-value.js
+++ b/lib/supported-value.js
@@ -32,6 +32,9 @@ module.exports = function (property, value) {
     } else {
         // Test value with vendor prefix.
         value = prefix.css + value
+        
+        //hardcode test to convert "flex" to "-ms-flexbox" for IE10
+        if(value === "-ms-flex") value = "-ms-flexbox"
         el.style[property] = value
 
         // Value is supported with vendor prefix.


### PR DESCRIPTION
added a test case for converting value of "flex" to "-ms-flexbox" in IE10 (instead of trying "-ms-flex" and failing)
